### PR TITLE
勉強会サイトのドキュメントルートの設定を変更

### DIFF
--- a/provision/group_vars/all.yml
+++ b/provision/group_vars/all.yml
@@ -10,6 +10,7 @@ domain: histudy.jp
 common_groups:
   - name: histudy
   - name: kakogawa_infra
+  - name: webadmin
 
 common_users:
   - name: wate
@@ -17,6 +18,7 @@ common_users:
     groups:
       - histudy
       - kakogawa_infra
+      - webadmin
     authorized_keys:
       - "https://github.com/wate.keys"
   - name: sperkbird
@@ -30,6 +32,7 @@ common_users:
     admin: yes
     groups:
       - histudy
+      - webadmin
     authorized_keys:
       - "https://github.com/nogajun.keys"
   - name: 223n
@@ -37,6 +40,7 @@ common_users:
     groups:
       - histudy
       - kakogawa_infra
+      - webadmin
     authorized_keys:
       - "https://github.com/223n.keys"
   - name: fu7mu4

--- a/provision/playbook.yml
+++ b/provision/playbook.yml
@@ -44,3 +44,8 @@
           when: result.stat.exists
       tags:
         - hostname
+    - name: change document root group and parmission
+      file:
+        path: /var/www/html
+        group: webadmin
+        mode: "g+w"


### PR DESCRIPTION
* Webサイト管理用のグループを追加
* Webサイト管理用グループに権限を付与するユーザーを所属させる
* 勉強会サイトのドキュメントルートディレクトリのグループを
  Webサイト管理用グループに変更し、グループに書き込み権限を付与する
